### PR TITLE
Introduce release-drafter + modernize CI (PHP 8.1, PHPUnit 9.6, svn, node 20)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,36 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+  - title: '📖 Documentation'
+    labels:
+      - 'documentation'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  release:
+    types: [ published ]
+
+permissions:
+  contents: write
+
+jobs:
+
+  release:
+    name: Build & Attach Zip
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ github.event.release.html_url }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP with composer v2
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          tools: composer
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Package
+        run: bash bin/build.sh ${{ github.event.release.tag_name }}
+
+      - uses: ./.github/actions/php-scoper
+        name: Do PHP Scoper
+        with:
+          scoper: 'yes'
+
+      - name: Clean Unwanted files
+        run: bash bin/clean.sh
+
+      - name: Create Zip
+        run: zip -r ${{ github.event.repository.name }}.zip ./
+
+      - name: Upload Release Asset
+        run: gh release upload "${{ github.event.release.tag_name }}" "./${{ github.event.repository.name }}.zip"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP with composer v2
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.1
           tools: composer
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ '7.4', '8.0' ] # PHP versions to check.
-        wp: [ 'latest', '5.9' ]      # WordPress version to check.
+        php: [ '8.1', '8.2', '8.3' ] # PHP versions to check.
+        wp: [ 'latest', '6.5' ]      # WordPress version to check.
         tools: [ composer ]
         scoper: [ 'yes', 'no' ]
     services:
@@ -78,7 +78,7 @@ jobs:
       - name: Setup PHP with composer v2
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.1
           tools: composer
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -58,6 +58,9 @@ jobs:
           sudo systemctl start mysql
           mysql -h 127.0.0.1 --port 3306 -u root --password=root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';"
 
+      - name: Install Subversion
+        run: sudo apt-get update && sudo apt-get install -y subversion
+
       - name: Install WordPress
         run: bash bin/install-wp-tests.sh wordpress root root 127.0.0.1:3306 ${{ matrix.wp }}
 
@@ -99,9 +102,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '20'
 
       - name: Install NPM Packages
         run: npm install

--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - '*'
   pull_request:
     branches:
       - master
@@ -120,57 +118,3 @@ jobs:
       - uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-
-  release:
-    name: Release Build as Plugin
-    needs: [ status-check ]
-    if: contains(github.ref, 'tags/')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup PHP with composer v2
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 7.4
-          tools: composer
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build Package
-        run: bash bin/build.sh
-
-      - uses: ./.github/actions/php-scoper
-        name: Do PHP Scoper
-        with:
-          scoper: 'yes'
-
-      - name: Clean Unwanted files
-        run: bash bin/clean.sh
-
-      - name: Create Zip
-        run: zip -r ${{ github.event.repository.name }}.zip ./
-
-      - name: Deploy Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Upload Release Zip
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/${{ github.event.repository.name }}.zip
-          asset_name: ${{ github.event.repository.name }}.zip
-          asset_content_type: application/zip

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 		}
 	},
 	"require-dev": {
-		"phpunit/phpunit": ">=5.7",
+		"phpunit/phpunit": "^9.6",
 		"wp-coding-standards/wpcs": "^3.0",
 		"yoast/phpunit-polyfills": "^1.0 || ^2.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		]
 	},
 	"require": {
-		"php": ">=7.2",
+		"php": ">=8.1",
 		"google/auth": "^1.9"
 	},
 	"autoload": {
@@ -46,7 +46,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "7.2"
+			"php": "8.1"
 		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true

--- a/ga-communicator.php
+++ b/ga-communicator.php
@@ -10,6 +10,7 @@
  * License URI: http://www.gnu.org/licenses/old-licenses/gpl-3.0.html
  * Text Domain: ga-communicator
  * Domain Path: /languages
+ * Requires PHP: 8.1
  */
 
 // This file actually do nothing.


### PR DESCRIPTION
## 概要

taro-sitemap に倣って release-drafter を導入。作業中に表面化した既存の CI 破綻も併せて修正した。

## 変更点

### release-drafter（本題）
- `.github/release-drafter.yml` 追加（taro-sitemap と同設定）
- `.github/workflows/release-drafter.yml` 追加（master push / PR でドラフト更新）
- リリースを `wordpress.yml` 内 release ジョブ（tag push）から独立 `release.yml`（`release: published` トリガー）へ分離。php-scoper + clean.sh は維持。`bin/build.sh` にタグを渡しバージョン空バグも修正
- `wordpress.yml` から release ジョブと push の `tags` トリガーを撤去

### 依存デッドロック解消
- `google/auth` + `firebase/php-jwt` が CVE-2025-45769（php-jwt <7.0.0）でブロックされ composer 解決不能だった
- **PHP 8.1 必須化**で `google/auth v1.50.2` + `firebase/php-jwt v7.0.5`（勧告対象外）に解決
- `composer.json` の `require.php` / `config.platform.php` を 8.1 に、プラグインヘッダに `Requires PHP: 8.1` を追加

### CI 老朽化の修正
- `phpunit/phpunit` を `^9.6` にピン（無指定だと PHPUnit 10/11 が入りスキーマ・テスト検出が非互換）
- ubuntu-latest から削除された `subversion` を apt 導入（install-wp-tests.sh の svn co 用）
- CI マトリクスを PHP 8.1/8.2/8.3 × WP latest/6.5 に更新
- assets ジョブの Node を 14 → 20 に

## 残課題

- `Check Assets`（node-sass がビルド不能）は別リポジトリ（@kunoichi/gulp-assets-task-set）の更新が絡むため分離: #79
- それ以外（UnitTest 全マトリクス・PHP Syntax）はグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)