### PR TITLE
Add watchtower release notification

### DIFF
--- a/.github/workflows/notify-watchtower.yml
+++ b/.github/workflows/notify-watchtower.yml
@@ -1,0 +1,21 @@
+# 外部パートナーが参加するリポにもそのまま置いてよい（シークレット・鍵はゼロ）。
+#
+# 動作:
+#   release が「リリース（prerelease ではない）」として publish されたら、
+#   tarosky/workflows の reusable workflow を呼び出して watchtower へ通知する。
+
+name: Notify watchtower on release
+
+on:
+  release:
+    types: [released]   # prerelease は除外。両方拾いたければ [released, prereleased] に変更
+
+jobs:
+  notify:
+    permissions:
+      id-token: write   # reusable 側ジョブの id-token: write はここから継承される
+      contents: read
+    uses: tarosky/workflows/.github/workflows/watchtower-notify.yml@main
+    # audience を上書きしたい場合のみ:
+    # with:
+    #   audience: watchtower


### PR DESCRIPTION
## What
Adds `.github/workflows/notify-watchtower.yml`, mirroring taro-sitemap.

## Behavior
- Triggers on `release: [released]` (prereleases excluded).
- Calls the reusable workflow `tarosky/workflows/.github/workflows/watchtower-notify.yml@main`.
- Uses GitHub OIDC (`id-token: write`). **No secrets / keys.**
- Plugin name derived server-side from the OIDC `repository` claim; only the version (tag) is sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)